### PR TITLE
fix: detect canvas structurally so node and web can share a process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for ppu-ocv. Listed maintainers are requested for review on every
+# pull request; any of them can satisfy a required code-owner approval.
+# See GOVERNANCE.md for roles.
+* @snowfluke @amaruki @saikanov @xirf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Node and web entry points can now be used in the same process.** Canvas
+  detection (`ImageProcessor` constructor, `CanvasProcessor.prepareCanvas`) used
+  the globally-registered platform's `isCanvas`, so once `ppu-ocv/web` was
+  loaded a Node-created canvas was rejected with "Invalid source type. Must be
+  either Canvas or cv.Mat." Detection is now structural (a new exported
+  `isCanvasLike`) and platform-independent, unblocking dual-target consumers and
+  test suites. ([#16](https://github.com/PT-Perkasa-Pilar-Utama/ppu-ocv/issues/16))
+
 ## [3.1.6] — 2026-05-24
 
 ### Security

--- a/src/canvas-factory.ts
+++ b/src/canvas-factory.ts
@@ -102,3 +102,23 @@ export function getPlatform(): CanvasPlatform {
   }
   return _platform;
 }
+
+/**
+ * Structural ("duck-typed") canvas check, independent of the registered
+ * platform. A value is canvas-like if it exposes `width`/`height` numbers and a
+ * `getContext` function — true for both `@napi-rs/canvas` (Node) and browser
+ * `HTMLCanvasElement`/`OffscreenCanvas`.
+ *
+ * Unlike {@link CanvasPlatform.isCanvas}, this does not depend on which platform
+ * is globally registered, so it stays correct when the Node and web entry
+ * points are loaded in the same process (e.g. a dual-target test suite).
+ */
+export function isCanvasLike(value: unknown): value is CanvasLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as CanvasLike).getContext === "function" &&
+    typeof (value as CanvasLike).width === "number" &&
+    typeof (value as CanvasLike).height === "number"
+  );
+}

--- a/src/canvas-processor.ts
+++ b/src/canvas-processor.ts
@@ -3,7 +3,7 @@
 
 import type { BoundingBox } from "./index.interface.js";
 import type { CanvasLike } from "./canvas-factory.js";
-import { getPlatform } from "./canvas-factory.js";
+import { getPlatform, isCanvasLike } from "./canvas-factory.js";
 
 /**
  * A detected region returned by {@link CanvasProcessor.findRegions}.
@@ -428,7 +428,7 @@ export class CanvasProcessor {
    * If the value is already a CanvasLike it is returned as-is.
    */
   static async prepareCanvas(file: ArrayBuffer): Promise<CanvasLike> {
-    if (getPlatform().isCanvas(file)) return file as unknown as CanvasLike;
+    if (isCanvasLike(file)) return file as unknown as CanvasLike;
 
     return getPlatform().loadImage(file);
   }

--- a/src/image-processor.ts
+++ b/src/image-processor.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 PT Perkasa Pilar Utama
 
 import type { CanvasLike } from "./canvas-factory.js";
-import { getPlatform } from "./canvas-factory.js";
+import { getPlatform, isCanvasLike } from "./canvas-factory.js";
 import { cv } from "./cv-provider.js";
 
 import type {
@@ -64,7 +64,7 @@ export class ImageProcessor {
    * @param source Source image as CanvasLike or cv.Mat
    */
   constructor(source: CanvasLike | cv.Mat) {
-    if (getPlatform().isCanvas(source)) {
+    if (isCanvasLike(source)) {
       const ctx = source.getContext("2d");
       const imageData = ctx.getImageData(0, 0, source.width, source.height);
       this.img = cv.matFromImageData(imageData);

--- a/tests/canvas-detection.test.ts
+++ b/tests/canvas-detection.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+import { describe, expect, test } from "bun:test";
+
+import { isCanvasLike } from "../src/canvas-factory.js";
+
+describe("isCanvasLike (platform-independent canvas detection)", () => {
+  test("accepts a Node-style canvas (@napi-rs: width/height/getContext/toBuffer)", () => {
+    const canvas = {
+      width: 10,
+      height: 10,
+      getContext: () => ({}),
+      toBuffer: () => Buffer.alloc(0),
+    };
+    expect(isCanvasLike(canvas)).toBe(true);
+  });
+
+  test("accepts a web-style canvas (width/height/getContext/toDataURL)", () => {
+    const canvas = { width: 10, height: 10, getContext: () => ({}), toDataURL: () => "" };
+    expect(isCanvasLike(canvas)).toBe(true);
+  });
+
+  test("rejects a cv.Mat-like object (rows/cols, no getContext)", () => {
+    expect(isCanvasLike({ rows: 10, cols: 10, data: new Uint8Array() })).toBe(false);
+  });
+
+  test("rejects ImageData-like, null, and primitives", () => {
+    expect(isCanvasLike({ width: 10, height: 10, data: new Uint8ClampedArray() })).toBe(false);
+    expect(isCanvasLike(null)).toBe(false);
+    expect(isCanvasLike("canvas")).toBe(false);
+    expect(isCanvasLike(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #16.

## What

Canvas detection in `ImageProcessor`'s constructor and
`CanvasProcessor.prepareCanvas` went through the globally-registered platform's
`isCanvas`. Once `ppu-ocv/web` registered its platform, a Node-created canvas
failed the web platform's `instanceof` check and threw:

```
Invalid source type. Must be either Canvas or cv.Mat.
```

This broke any process that loads both the `ppu-ocv` (node) and `ppu-ocv/web`
entry points — e.g. a dual-target test suite.

## How

- Add a platform-independent structural check `isCanvasLike` (width/height
  numbers + a `getContext` function) to `canvas-factory.ts`.
- Use it at both call sites instead of `getPlatform().isCanvas(...)`.

A `cv.Mat` (no `getContext`) still falls through to the `instanceof cv.Mat`
branch, and `ImageData` (no `getContext`) is correctly rejected.

## Tests

- New `tests/canvas-detection.test.ts` covers node-style, web-style, Mat-like,
  ImageData-like, null, and primitive inputs.
- Full suite: 91 existing + 4 new pass, no regression.

## Also

Adds `.github/CODEOWNERS` (maintainers) to enable required code-owner review.

## Compatibility

No API break. `isCanvasLike` is a new export; `CanvasPlatform.isCanvas` is
unchanged.