### PR TITLE
chore: reproducible-build verification + fuzz testing (Gold prep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,20 @@ jobs:
       - name: Build
         run: bun run build
 
+      # Verify the build is reproducible: build a second time and confirm the
+      # output is byte-identical (OpenSSF Best Practices: build_reproducible).
+      - name: Verify reproducible build
+        run: |
+          h1=$(find lib -type f -exec shasum {} \; | sort | shasum)
+          rm -rf lib
+          bun run build
+          h2=$(find lib -type f -exec shasum {} \; | sort | shasum)
+          if [ "$h1" != "$h2" ]; then
+            echo "::error::Build is not reproducible: $h1 != $h2"
+            exit 1
+          fi
+          echo "Build is reproducible."
+
   sca:
     name: SCA (dependency vulnerabilities)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Reproducible-build verification.** CI now builds twice and fails if the
   output is not byte-identical; `docs/REPRODUCIBLE_BUILD.md` documents the
   deterministic build and how to verify it (OpenSSF Best Practices Gold).
+- **Fuzz testing (dynamic analysis).** `tests/fuzz.test.ts` uses `fast-check` to
+  feed many random inputs to the image decoder on every CI run, asserting it
+  never crashes on malformed input — exercising the untrusted-input boundary
+  from the threat model (OpenSSF Best Practices Gold dynamic_analysis).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Reproducible-build verification.** CI now builds twice and fails if the
+  output is not byte-identical; `docs/REPRODUCIBLE_BUILD.md` documents the
+  deterministic build and how to verify it (OpenSSF Best Practices Gold).
+
 ### Fixed
 
 - **Node and web entry points can now be used in the same process.** Canvas

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@types/uglify-js": "latest",
         "@typescript/native-preview": "^7.0.0-dev.20260513.1",
         "canvas": "^3.2.3",
+        "fast-check": "^4.8.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
         "mitata": "latest",
@@ -239,6 +240,8 @@
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -294,6 +297,8 @@
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 

--- a/docs/REPRODUCIBLE_BUILD.md
+++ b/docs/REPRODUCIBLE_BUILD.md
@@ -1,0 +1,35 @@
+# Reproducible build
+
+ppu-ocv produces a **byte-identical** build from the same source: rebuilding the
+package yields the same `lib/` output, with no embedded timestamps, absolute
+paths, or other nondeterministic data.
+
+## Why it is deterministic
+
+`bun run build` (see `scripts/build.ts`) transpiles `src/**/*.ts` to `lib/` with
+Bun's transpiler and writes type declarations. The transform is a pure function
+of the source files and the pinned toolchain:
+
+- **Toolchain is pinned.** Bun is pinned to 1.2.23 in CI; dependencies are
+  pinned in `bun.lock` and installed with `--frozen-lockfile`.
+- **No nondeterministic inputs.** The build embeds no build time, hostname, or
+  absolute path. File order is sorted; output is whitespace-minified
+  deterministically.
+
+## Verify it yourself
+
+```bash
+bun install --frozen-lockfile
+bun run build
+h1=$(find lib -type f -exec shasum {} \; | sort | shasum)
+
+rm -rf lib
+bun run build
+h2=$(find lib -type f -exec shasum {} \; | sort | shasum)
+
+[ "$h1" = "$h2" ] && echo "reproducible" || echo "NOT reproducible"
+```
+
+Both hashes match. CI enforces this on every push and pull request via the
+**"Verify reproducible build"** step in `.github/workflows/ci.yml`, which builds
+twice and fails if the output differs.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/uglify-js": "latest",
     "@typescript/native-preview": "^7.0.0-dev.20260513.1",
     "canvas": "^3.2.3",
+    "fast-check": "^4.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "mitata": "latest",

--- a/tests/fuzz.test.ts
+++ b/tests/fuzz.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 PT Perkasa Pilar Utama
+
+/**
+ * Dynamic analysis (fuzzing) of the untrusted-input boundary. `fast-check`
+ * generates many random inputs at runtime and exercises the image decoder; a
+ * crash, hang, or non-Error throw is a finding. Assertions are enabled
+ * throughout (the property uses `expect`).
+ */
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { CanvasProcessor } from "../src/index.canvas.js";
+
+describe("fuzz: image decoding is robust to malformed input", () => {
+  test("prepareCanvas never crashes on arbitrary bytes", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.uint8Array({ maxLength: 8192 }), async (bytes) => {
+        try {
+          const canvas = await CanvasProcessor.prepareCanvas(bytes.buffer as ArrayBuffer);
+          // If a random buffer happened to decode, the result must be sane.
+          expect(canvas.width).toBeGreaterThanOrEqual(0);
+          expect(canvas.height).toBeGreaterThanOrEqual(0);
+        } catch (error) {
+          // Malformed input must fail gracefully with a normal Error — never a
+          // native crash, hang, or non-Error throw.
+          expect(error).toBeInstanceOf(Error);
+        }
+      }),
+      { numRuns: 250 }
+    );
+  }, 60000);
+
+  test("prepareCanvas rejects an empty buffer gracefully", async () => {
+    await expect(CanvasProcessor.prepareCanvas(new ArrayBuffer(0))).rejects.toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
Prepares the two non-people OpenSSF Best Practices **Gold** criteria that we can
earn without waiting on contributor activity.

## Reproducible build (`build_reproducible`)
- CI builds twice and fails if `lib/` output is not byte-identical.
- `docs/REPRODUCIBLE_BUILD.md` documents the deterministic build + how to verify.

## Fuzz testing (`dynamic_analysis`, `dynamic_analysis_enable_assertions`)
- `tests/fuzz.test.ts` uses `fast-check` to feed many random byte arrays to
  `CanvasProcessor.prepareCanvas` on every CI run, asserting the decoder fails
  gracefully (a normal `Error`) rather than crashing or hanging.
- Exercises the untrusted-input boundary from `docs/THREAT_MODEL.md`.
- Runs with assertions enabled (the property uses `expect`).

## Tests
- New fuzz suite: 2 pass. Reproducibility verified locally (identical hashes).
- No API change; `fast-check` is a devDependency only.

## Notes
After this merges, the remaining Gold gaps are the people-criteria
(`bus_factor`, `contributors_unassociated`, `two_person_review`), which flip
once @xirf's reviewed PR (#13) lands. `test_branch_coverage80` stays N/A (bun's
runner does not report branch coverage).