### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.2.0] — 2026-05-24
+
 ### Added
 
 - **Reproducible-build verification.** CI now builds twice and fails if the
@@ -64,8 +66,6 @@ new ImageProcessor(canvas)
 ```
 
 Closes [#13](https://github.com/PT-Perkasa-Pilar-Utama/ppu-ocv/issues/13).
-
-## [3.1.6] — 2026-05-24
 
 ### Security
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-ocv",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-ocv",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "description": "A type-safe, modular, chainable image processing library built on top of OpenCV.js with a fluent API leveraging pipeline processing.",
   "keywords": [
     "open-cv",


### PR DESCRIPTION
Minor release: adds the `equalize` (CLAHE) operation (#13), and bundles the supply-chain hardening, dual-target canvas fix (#16/#17), reproducible-build verification, and fuzz testing accumulated on main. The prepped-but-unreleased 3.1.6 notes are folded into 3.2.0.