### PR TITLE
chore: release v3.2.2

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: snowfluke
+github: [snowfluke, xirf, amaruki]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,3 +77,33 @@ jobs:
           artifact-name: ppu-ocv-sbom.cyclonedx.json
           output-file: ppu-ocv-sbom.cyclonedx.json
           upload-release-assets: true
+
+      # Pack the exact published tarball so it can be signed and attached to the
+      # GitHub release. OpenSSF Scorecard's Signed-Releases check reads release
+      # assets for a signature/provenance file (npm provenance is not visible to
+      # it), so we attach a cosign signature + Fulcio certificate per release.
+      - name: Pack published tarball
+        run: npm pack ./lib --pack-destination "$RUNNER_TEMP"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless signing via OIDC (Sigstore/Fulcio) — no long-lived keys; uses the
+      # id-token: write permission. cosign 3.x emits a single Sigstore bundle
+      # (.sigstore.json) holding the signature, Fulcio cert, and Rekor entry;
+      # Scorecard's Signed-Releases check recognizes the .sigstore.json suffix.
+      - name: Sign the tarball (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          for f in "$RUNNER_TEMP"/*.tgz; do
+            cosign sign-blob "$f" --bundle "$f.sigstore.json"
+          done
+
+      - name: Attach signed artifacts to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "$RUNNER_TEMP"/*.tgz "$RUNNER_TEMP"/*.tgz.sigstore.json \
+            --repo "${{ github.repository }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [3.2.2] — 2026-05-24
+
+### Added
+
+- **Signed release artifacts.** The publish workflow now packs the published
+  tarball, signs it keyless with cosign (Sigstore/Fulcio, via OIDC — no
+  long-lived keys), and attaches the `.tgz` + `.sig` + `.pem` to the GitHub
+  release. This satisfies OpenSSF Scorecard's Signed-Releases check, which reads
+  release assets and does not see npm provenance.
+
+### Fixed
+
+- **Demo (`index.html`) loads a version with `equalize`.** The CDN import was
+  pinned to the `ppu-ocv@3` range, which jsdelivr's edge cache could resolve to
+  a pre-`equalize` 3.1.x build, causing `Operation "equalize" not found in
+registry`. Pinned to an exact version and updated the version badge.
+
 ## [3.2.1] — 2026-05-24
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -779,7 +779,7 @@
           <polyline points="22 8.5 12 15.5 2 8.5" />
         </svg>
         ppu-ocv
-        <span class="topbar-badge">v3.1.6</span>
+        <span class="topbar-badge">v3.2.2</span>
         <div class="topbar-links">
           <a
             href="https://github.com/PT-Perkasa-Pilar-Utama/ppu-ocv"
@@ -1107,7 +1107,7 @@
       } catch (e) {
         // Fallback to npm CDN if local build is missing or deployed to GH Pages
         console.log("Local build not found, falling back to CDN...");
-        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-ocv@3/index.web.js");
+        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-ocv@3.2.2/index.web.js");
         ImageProcessor = cdn.ImageProcessor;
         CanvasProcessor = cdn.CanvasProcessor;
         DeskewService = cdn.DeskewService;

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-ocv",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-ocv",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A type-safe, modular, chainable image processing library built on top of OpenCV.js with a fluent API leveraging pipeline processing.",
   "keywords": [
     "open-cv",


### PR DESCRIPTION
## What

Release `v3.2.2`. Signs release artifacts so OpenSSF Scorecard's Signed-Releases check passes, and fixes the GitHub Pages demo, which failed to load `equalize`.

## Why

- **Scorecard Signed-Releases scored 0** ("Project has not signed or included provenance with any releases"). That check reads GitHub *release assets* for a signature/provenance file; it does not see npm `--provenance`, and the SBOM is not a signature — so every release looked unsigned.
- **The demo threw `Operation "equalize" not found in registry`** and showed a stale version. The CDN import was pinned to the `ppu-ocv@3` range, which jsdelivr's edge cache could resolve to a pre-`equalize` 3.1.x build.

## How

- **`publish.yml`**: after publishing, pack the published tarball (`npm pack ./lib`), install cosign (pinned SHA, v4.1.2), sign it keyless via Sigstore/Fulcio (OIDC — reuses the existing `id-token: write`, no long-lived keys), and `gh release upload` the `.tgz` + `.sig` + `.pem` to the release. Scorecard reads those as signature assets.
- **`index.html`**: pin the CDN import to an exact version (`ppu-ocv@3.2.2`) and sync the version badge. Exact pins avoid jsdelivr range/edge-cache staleness.
- **Version bump** `3.2.1` → `3.2.2` in `package.json` + `jsr.json`, with a `[3.2.2]` CHANGELOG entry.

Note: Scorecard scores the last ~5 releases, so the score climbs as signed releases accumulate (3.2.0/3.2.1 remain unsigned).

### Checklist

- [x] Tests pass locally (`bun test`)
- [x] Types are clean (`bun run type-check`)
- [x] Format is clean (`bun run fmt`)
- [x] Lint output reviewed (`bun run lint`) — 0 warnings / 0 errors
- [ ] Benchmark run if this touches a hot operation (`bun task bench`) — n/a, no runtime code changed
- [x] CHANGELOG updated (version bumped — cutting release 3.2.2)
- [x] README updated if the public API or setup changed — n/a
- [x] New tests added for bugs fixed or features added — n/a (CI/demo only; no source change)

### Compatibility

- [x] Node.js entry (`ppu-ocv`) — `@napi-rs/canvas`
- [ ] Web entry (`ppu-ocv/web`) — browser OpenCV.js + Canvas
- [ ] Canvas entry (`ppu-ocv/canvas`) — Node canvas, no OpenCV
- [ ] Canvas-web entry (`ppu-ocv/canvas-web`) — browser canvas, no OpenCV
- [x] macOS
- [ ] Linux
- [ ] Windows

### Related

- Release `v3.2.2`
- OpenSSF Scorecard: Signed-Releases