### PR TITLE
perf: optimize deskew angle calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@
   (e.g. `"file:///…"` on mobile, `"https://…"` where the platform supports it)
   without a separate fetch step.
 
+### Changed
+
+- **Deskew baseline heuristic uses spatial x-thirds.** `calculateBaselineAngles`
+  now buckets each region's contour points into three equal-width `x` segments
+  (left/center/right thirds) and fits the max-`y` point of each, replacing the
+  prior sort-and-split-by-count approach. This is faster on large contours but
+  is a behavior change: on non-uniform point distributions the selected baseline
+  points — and therefore the estimated skew angle — can differ slightly, and
+  sparse or near-vertical contours that collapse into a single bucket now
+  contribute no baseline vote. Direct unit tests pin the new behavior.
+
+### Internal Changes
+
+- **Faster deskew angle estimation.** `calculateLineAngle` and
+  `calculateConsensusAngle` accumulate their sums in a single pass instead of
+  multiple `reduce` passes (no behavior change), and `calculateBaselineAngles`
+  scans contours linearly instead of sorting. Largest gains are on dense
+  contours (~3–6× on 10k–100k-point inputs); see `bench/deskew-angles.bench.ts`.
+
 ## [3.2.2] — 2026-05-24
 
 ### Added

--- a/bench/deskew-angles.bench.ts
+++ b/bench/deskew-angles.bench.ts
@@ -1,0 +1,187 @@
+import { bench, do_not_optimize, run } from "mitata";
+import {
+  calculateBaselineAngles,
+  calculateConsensusAngle,
+  calculateLineAngle,
+  calculateMinRectAngles,
+} from "../src/deskew-angles";
+import type { TextRegion, WeightedAngle } from "../src/deskew-angles";
+
+type BenchContext<T> = { get(name: string): T };
+
+function makePoints(pointCount: number, slope = 0.03): Array<{ x: number; y: number }> {
+  return Array.from({ length: pointCount }, (_, i) => ({
+    x: i,
+    y: Math.round(i * slope + Math.sin(i / 41) * 8 + Math.cos(i / 97) * 3),
+  }));
+}
+
+function makeRegion(pointCount: number, slope = 0.03, offsetX = 0): TextRegion {
+  const data = new Int32Array(pointCount * 2);
+
+  for (let i = 0; i < pointCount; i++) {
+    const x = offsetX + i;
+    const y = Math.round(i * slope + Math.sin(i / 37) * 11 + Math.cos(i / 113) * 5);
+    data[i * 2] = x;
+    data[i * 2 + 1] = y;
+  }
+
+  return {
+    contour: {
+      data32S: data,
+    } as unknown as TextRegion["contour"],
+    area: pointCount,
+    aspectRatio: 4,
+  };
+}
+
+function makeMinRectRegion(area: number, aspectRatio: number): TextRegion {
+  return {
+    contour: {
+      data32S: new Int32Array([0, 0, 10, 0, 10, 10, 0, 10]),
+    } as unknown as TextRegion["contour"],
+    area,
+    aspectRatio,
+  };
+}
+
+function makeConsensusAngles(count: number): Array<WeightedAngle & { method: string }> {
+  const methods = ["minRect", "baseline", "hough"];
+
+  return Array.from({ length: count }, (_, i) => ({
+    angle: Math.sin(i / 17) * 4 + Math.cos(i / 53) * 1.5,
+    weight: 1 + (i % 31),
+    method: methods[i % methods.length] ?? "minRect",
+  }));
+}
+
+function makeMinRectCvStub() {
+  const previous = globalThis.cv;
+
+  globalThis.cv = {
+    ...previous,
+    minAreaRect: ((_contour: TextRegion["contour"]) => ({
+      angle: 12,
+    })) as typeof globalThis.cv.minAreaRect,
+  };
+
+  return () => {
+    globalThis.cv = previous;
+  };
+}
+
+const pointSets = {
+  "line-angle/3": makePoints(3),
+  "line-angle/100": makePoints(100),
+  "line-angle/10k": makePoints(10_000),
+  "line-angle/100k": makePoints(100_000),
+};
+
+const singleRegions = {
+  "baseline/1k-points/1-region": [makeRegion(1_000)],
+  "baseline/10k-points/1-region": [makeRegion(10_000)],
+  "baseline/100k-points/1-region": [makeRegion(100_000)],
+};
+
+const multiRegions = {
+  "baseline/100-regions/100-points": Array.from({ length: 100 }, (_, i) =>
+    makeRegion(100, 0.02 + (i % 5) * 0.005, i * 200)
+  ),
+  "baseline/100-regions/1k-points": Array.from({ length: 100 }, (_, i) =>
+    makeRegion(1_000, 0.02 + (i % 5) * 0.005, i * 2_000)
+  ),
+};
+
+const consensusSets = {
+  "consensus/10-angles": makeConsensusAngles(10),
+  "consensus/1k-angles": makeConsensusAngles(1_000),
+  "consensus/10k-angles": makeConsensusAngles(10_000),
+};
+
+for (const [name, points] of Object.entries(pointSets)) {
+  bench(name, function* (ctx: BenchContext<typeof points>) {
+    const input = ctx.get("points");
+
+    yield {
+      [0]() {
+        return input;
+      },
+
+      bench(points: typeof input) {
+        return do_not_optimize(calculateLineAngle(points));
+      },
+    };
+  }).args("points", [points]);
+}
+
+for (const [name, regions] of Object.entries(singleRegions)) {
+  bench(name, function* (ctx: BenchContext<typeof regions>) {
+    const input = ctx.get("regions");
+
+    yield {
+      [0]() {
+        return input;
+      },
+
+      bench(regions: typeof input) {
+        return do_not_optimize(calculateBaselineAngles(regions));
+      },
+    };
+  }).args("regions", [regions]);
+}
+
+for (const [name, regions] of Object.entries(multiRegions)) {
+  bench(name, function* (ctx: BenchContext<typeof regions>) {
+    const input = ctx.get("regions");
+
+    yield {
+      [0]() {
+        return input;
+      },
+
+      bench(regions: typeof input) {
+        return do_not_optimize(calculateBaselineAngles(regions));
+      },
+    };
+  }).args("regions", [regions]);
+}
+
+for (const [name, angles] of Object.entries(consensusSets)) {
+  bench(name, function* (ctx: BenchContext<typeof angles>) {
+    const input = ctx.get("angles");
+
+    yield {
+      [0]() {
+        return input;
+      },
+
+      bench(angles: typeof input) {
+        return do_not_optimize(calculateConsensusAngle(angles, -15, 15, () => undefined));
+      },
+    };
+  })
+    .args("angles", [angles])
+    .gc("inner");
+}
+
+const restoreCv = makeMinRectCvStub();
+const minRectRegions = Array.from({ length: 10_000 }, (_, i) =>
+  makeMinRectRegion(100 + i, 1.5 + (i % 10) / 10)
+);
+
+bench("min-rect/10k-regions", function* (ctx: BenchContext<typeof minRectRegions>) {
+  const input = ctx.get("regions");
+
+  yield {
+    [0]() {
+      return input;
+    },
+
+    bench(regions: typeof input) {
+      return do_not_optimize(calculateMinRectAngles(regions));
+    },
+  };
+}).args("regions", [minRectRegions]);
+
+await run();
+restoreCv();

--- a/src/deskew-angles.ts
+++ b/src/deskew-angles.ts
@@ -77,38 +77,41 @@ export function calculateBaselineAngles(textRegions: TextRegion[]): WeightedAngl
       const points = region.contour.data32S;
       if (!points || points.length < 8) continue;
 
-      const bottomPoints: Array<{ x: number; y: number }> = [];
+      // First pass: find x bounds
+      let minX = Infinity;
+      let maxX = -Infinity;
+
+      for (let i = 0; i < points.length; i += 2) {
+        const x = points[i];
+        if (x !== undefined) {
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+        }
+      }
+
+      if (minX === Infinity) continue;
+
+      // Second pass: bucket into 3 x-segments, track max-y per bucket
+      const bucketMaxY: Array<{ x: number; y: number } | null> = [null, null, null];
+      const xRange = maxX - minX || 1;
 
       for (let i = 0; i < points.length; i += 2) {
         const x = points[i];
         const y = points[i + 1];
-        if (x !== undefined && y !== undefined) {
-          bottomPoints.push({ x, y });
+        if (x === undefined || y === undefined) continue;
+
+        const bucket = Math.min(2, Math.floor(((x - minX) / xRange) * 3));
+        const current = bucketMaxY[bucket];
+        if (current === null || y > current.y) {
+          bucketMaxY[bucket] = { x, y };
         }
       }
 
-      if (bottomPoints.length < 3) continue;
-      bottomPoints.sort((a, b) => a.x - b.x);
-
-      const segments = 3;
-      const segmentSize = Math.floor(bottomPoints.length / segments);
-      const baselinePoints: Array<{ x: number; y: number }> = [];
-
-      for (let seg = 0; seg < segments; seg++) {
-        const start = seg * segmentSize;
-        const end = seg === segments - 1 ? bottomPoints.length : (seg + 1) * segmentSize;
-        const segmentPoints = bottomPoints.slice(start, end);
-
-        if (segmentPoints.length > 0) {
-          const maxYPoint = segmentPoints.reduce((max, point) => (point.y > max.y ? point : max));
-          baselinePoints.push(maxYPoint);
-        }
-      }
+      const baselinePoints = bucketMaxY.filter((p): p is { x: number; y: number } => p !== null);
 
       if (baselinePoints.length >= 2) {
         const angle = calculateLineAngle(baselinePoints);
         const weight = region.area * Math.min(region.aspectRatio, 1 / region.aspectRatio);
-
         angles.push({ angle, weight });
       }
     } catch {

--- a/src/deskew-angles.ts
+++ b/src/deskew-angles.ts
@@ -208,23 +208,17 @@ export function calculateConsensusAngle(
     return sortedAngles[medianIndex]?.angle || 0;
   }
 
-  const totalWeight = filteredAngles.reduce((sum, a) => sum + a.weight, 0);
+  let totalWeight = 0;
+  let weightedSum = 0;
+  let unweightedSum = 0;
+  const methodCounts: Record<string, number> = {};
 
-  if (totalWeight === 0) {
-    const average = filteredAngles.reduce((sum, a) => sum + a.angle, 0) / filteredAngles.length;
-    return average;
+  for (const a of filteredAngles) {
+    totalWeight += a.weight;
+    weightedSum += a.angle * a.weight;
+    unweightedSum += a.angle;
+    methodCounts[a.method] = (methodCounts[a.method] || 0) + 1;
   }
-
-  const weightedSum = filteredAngles.reduce((sum, a) => sum + a.angle * a.weight, 0);
-  const weightedAverage = weightedSum / totalWeight;
-
-  const methodCounts = filteredAngles.reduce(
-    (counts, a) => {
-      counts[a.method] = (counts[a.method] || 0) + 1;
-      return counts;
-    },
-    {} as Record<string, number>
-  );
 
   log(
     `Angle methods used: ${Object.entries(methodCounts)
@@ -232,5 +226,10 @@ export function calculateConsensusAngle(
       .join(", ")}`
   );
 
+  if (totalWeight === 0) {
+    return unweightedSum / filteredAngles.length;
+  }
+
+  const weightedAverage = weightedSum / totalWeight;
   return Math.max(minAngle, Math.min(maxAngle, weightedAverage));
 }

--- a/src/deskew-angles.ts
+++ b/src/deskew-angles.ts
@@ -97,7 +97,10 @@ export function calculateBaselineAngles(textRegions: TextRegion[]): WeightedAngl
 
       if (minX === Infinity) continue;
 
-      // Second pass: bucket into 3 x-segments, track max-y per bucket
+      // Second pass: bucket into 3 equal-width x-segments (left/center/right
+      // thirds of the region), tracking the max-y point per bucket. This is a
+      // spatial split, not the prior equal-count split; empty buckets (sparse
+      // or near-vertical contours) yield fewer baseline points by design.
       const bucketMaxY: Array<{ x: number; y: number } | null> = [null, null, null];
       const xRange = maxX - minX || 1;
 
@@ -220,15 +223,15 @@ export function calculateConsensusAngle(
     methodCounts[a.method] = (methodCounts[a.method] || 0) + 1;
   }
 
+  if (totalWeight === 0) {
+    return unweightedSum / filteredAngles.length;
+  }
+
   log(
     `Angle methods used: ${Object.entries(methodCounts)
       .map(([method, count]) => `${method}:${count}`)
       .join(", ")}`
   );
-
-  if (totalWeight === 0) {
-    return unweightedSum / filteredAngles.length;
-  }
 
   const weightedAverage = weightedSum / totalWeight;
   return Math.max(minAngle, Math.min(maxAngle, weightedAverage));

--- a/src/deskew-angles.ts
+++ b/src/deskew-angles.ts
@@ -20,13 +20,19 @@ export function calculateLineAngle(points: Array<{ x: number; y: number }>): num
   if (points.length < 2) return 0;
 
   const n = points.length;
-  const sumX = points.reduce((sum, p) => sum + p.x, 0);
-  const sumY = points.reduce((sum, p) => sum + p.y, 0);
-  const sumXY = points.reduce((sum, p) => sum + p.x * p.y, 0);
-  const sumXX = points.reduce((sum, p) => sum + p.x * p.x, 0);
+  let sumX = 0,
+    sumY = 0,
+    sumXY = 0,
+    sumXX = 0;
+
+  for (const p of points) {
+    sumX += p.x;
+    sumY += p.y;
+    sumXY += p.x * p.y;
+    sumXX += p.x * p.x;
+  }
 
   const denominator = n * sumXX - sumX * sumX;
-
   if (Math.abs(denominator) < 1e-10) return 0;
 
   const slope = (n * sumXY - sumX * sumY) / denominator;

--- a/tests/deskew-angles.test.ts
+++ b/tests/deskew-angles.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import {
+  calculateBaselineAngles,
+  calculateConsensusAngle,
+  calculateLineAngle,
+} from "../src/deskew-angles";
+import type { TextRegion, WeightedAngle } from "../src/deskew-angles";
+
+/** Build a TextRegion whose contour exposes only the `data32S` the helpers read. */
+function region(coords: number[], area = 100, aspectRatio = 4): TextRegion {
+  return {
+    contour: { data32S: new Int32Array(coords) } as unknown as TextRegion["contour"],
+    area,
+    aspectRatio,
+  };
+}
+
+describe("calculateLineAngle", () => {
+  test("returns 0 for fewer than two points", () => {
+    expect(calculateLineAngle([])).toBe(0);
+    expect(calculateLineAngle([{ x: 1, y: 1 }])).toBe(0);
+  });
+
+  test("returns 0 for a horizontal line", () => {
+    expect(
+      calculateLineAngle([
+        { x: 0, y: 5 },
+        { x: 10, y: 5 },
+      ])
+    ).toBe(0);
+  });
+
+  test("returns 0 for a vertical line (degenerate denominator)", () => {
+    expect(
+      calculateLineAngle([
+        { x: 3, y: 0 },
+        { x: 3, y: 10 },
+        { x: 3, y: 20 },
+      ])
+    ).toBe(0);
+  });
+
+  test("fits the least-squares slope as a degree angle", () => {
+    expect(
+      calculateLineAngle([
+        { x: 0, y: 0 },
+        { x: 10, y: 1 },
+      ])
+    ).toBeCloseTo(5.7106, 3);
+  });
+
+  test("clamps slopes steeper than 45 degrees into the ±45 band", () => {
+    // slope 2 → atan ≈ 63.43°, wrapped to 63.43 - 90 = -26.57°
+    expect(
+      calculateLineAngle([
+        { x: 0, y: 0 },
+        { x: 1, y: 2 },
+      ])
+    ).toBeCloseTo(-26.565, 3);
+  });
+});
+
+describe("calculateBaselineAngles", () => {
+  // Pins the equal-WIDTH (spatial thirds) heuristic introduced in this change,
+  // not the prior equal-COUNT split. The x distribution below is non-uniform:
+  // an equal-count split would partition by rank and select different points.
+  test("buckets points into spatial x-thirds and fits the max-y per third", () => {
+    // bucket0 [0,30): (0,10) (5,50) (20,30) → max-y (5,50)
+    // bucket1 [30,60): (40,80) (45,20)       → max-y (40,80)
+    // bucket2 [60,90]: (70,100) (90,60)       → max-y (70,100)
+    const out = calculateBaselineAngles([
+      region([0, 10, 5, 50, 20, 30, 40, 80, 45, 20, 70, 100, 90, 60], 100, 4),
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.angle).toBeCloseTo(37.6557, 3);
+    // weight = area * min(aspectRatio, 1/aspectRatio) = 100 * 0.25
+    expect(out[0]?.weight).toBeCloseTo(25, 6);
+  });
+
+  test("skips contours with fewer than 8 int32 values", () => {
+    expect(calculateBaselineAngles([region([0, 0, 1, 1, 2, 2])])).toEqual([]);
+  });
+
+  test("skips near-vertical contours that collapse into a single bucket", () => {
+    // All points share one x → xRange falls back to 1 → every point lands in
+    // bucket 0 → a single baseline point → region contributes no vote.
+    expect(calculateBaselineAngles([region([3, 0, 3, 10, 3, 20, 3, 30])])).toEqual([]);
+  });
+
+  test("still fits when only two of three buckets are populated", () => {
+    // Points fall only in bucket0 [0,30) and bucket2 [60,90]; middle stays empty.
+    const out = calculateBaselineAngles([region([0, 10, 5, 50, 70, 100, 90, 60])]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.angle).toBeCloseTo(37.5686, 3);
+  });
+});
+
+describe("calculateConsensusAngle", () => {
+  const noopLog = () => {};
+  const angle = (
+    a: number,
+    weight: number,
+    method = "baseline"
+  ): WeightedAngle & {
+    method: string;
+  } => ({ angle: a, weight, method });
+
+  test("returns 0 for an empty candidate set", () => {
+    expect(calculateConsensusAngle([], -20, 20, noopLog)).toBe(0);
+  });
+
+  test("computes the weighted mean of inliers", () => {
+    const out = calculateConsensusAngle([angle(2, 1), angle(4, 3)], -20, 20, noopLog);
+    // (2*1 + 4*3) / (1+3) = 14/4 = 3.5
+    expect(out).toBeCloseTo(3.5, 6);
+  });
+
+  test("falls back to the median when every candidate is out of range", () => {
+    let message = "";
+    // Both angles exceed maxAngle, so the range filter empties the inlier set
+    // and the function returns the median of the original sorted candidates.
+    const out = calculateConsensusAngle([angle(18, 1), angle(19, 1)], -10, 10, (m) => {
+      message = m;
+    });
+    expect(out).toBe(19);
+    expect(message).toContain("filtered out");
+  });
+
+  // F2: the totalWeight === 0 path returns the unweighted mean and must NOT log.
+  test("returns the unweighted mean and does not log when total weight is 0", () => {
+    let logged = false;
+    const out = calculateConsensusAngle([angle(2, 0), angle(6, 0)], -20, 20, () => {
+      logged = true;
+    });
+    expect(out).toBeCloseTo(4, 6);
+    expect(logged).toBe(false);
+  });
+
+  test("logs the method mix on the weighted path", () => {
+    let message = "";
+    calculateConsensusAngle([angle(2, 1, "hough"), angle(4, 2, "hough")], -20, 20, (m) => {
+      message = m;
+    });
+    expect(message).toContain("hough:2");
+  });
+});


### PR DESCRIPTION
## What

Improves performance in `src/deskew-angles.ts`, mainly for deskew inputs with larger contour point sets, and changes the baseline-angle heuristic (see **How** — this is an intentional behavior change, not a pure refactor).

This PR also adds `bench/deskew-angles.bench.ts` so the deskew angle helpers can be benchmarked directly, and `tests/deskew-angles.test.ts` to pin the helpers' behavior.

## Why

`calculateBaselineAngles` and `calculateLineAngle` are used while estimating document skew. On larger contours, the old implementation spent extra time doing repeated passes and sort/slice work that was not necessary for the final result.

The practical improvement is best seen on larger point sets:

| Benchmark                        |         Before |          After |       Result |
| -------------------------------- | -------------: | -------------: | -----------: |
| `line-angle/10k`                 | 306.26 µs/iter | 104.65 µs/iter | ~2.9x faster |
| `line-angle/100k`                |   3.57 ms/iter | 859.08 µs/iter | ~4.2x faster |
| `baseline/10k-points/1-region`   | 524.62 µs/iter | 137.91 µs/iter | ~3.8x faster |
| `baseline/100k-points/1-region`  |   8.30 ms/iter |   1.41 ms/iter | ~5.9x faster |
| `baseline/100-regions/1k-points` |   4.91 ms/iter |   1.57 ms/iter | ~3.1x faster |
| `consensus/10k-angles`           |   4.44 ms/iter |   3.82 ms/iter | ~1.2x faster |

One small-region benchmark is slower:

| Benchmark                         |         Before |        After |
| --------------------------------- | -------------: | -----------: |
| `baseline/100-regions/100-points` | 662.48 µs/iter | 1.33 ms/iter |

That case is many tiny regions. The main target for this change is larger/dense contours, where the previous implementation scaled worse.

Benchmarks were run locally with:

```bash
bun task bench deskew-angles
```

Environment:

CPU: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
Runtime: bun 1.3.14 (x64-linux)

Full local benchmark notes were kept outside the PR branch and are not included in this PR.

## How

The changes are focused in `src/deskew-angles.ts`:

- **`calculateLineAngle`** — behavior-preserving. Uses one accumulation pass instead of multiple `reduce` passes over the same points.
- **`calculateConsensusAngle`** — behavior-preserving. Aggregates total weight, weighted sum, unweighted sum, and method counts in a single pass instead of repeated `reduce` calls. The `Angle methods used` log stays below the `totalWeight === 0` early return, so its log output is unchanged.
- **`calculateBaselineAngles`** — **intentional behavior change, not equivalent.** The old code sorted contour points by `x` and split them into three **equal-count** segments by index, taking the max-`y` point of each. It now buckets points into three **equal-width** `x` segments (left/center/right thirds of the region) and takes the max-`y` per bucket. This is a spatial split, which:
  - avoids the sort and scales better on large/dense contours, and
  - more directly samples the left/center/right of the region for the baseline fit.

  Consequences (covered by tests):
  - On non-uniform `x` distributions (the normal case) the selected baseline points — and therefore the estimated angle — can differ slightly from before.
  - Sparse or near-vertical contours whose points collapse into a single bucket now yield fewer than three baseline points (or none), so such a region contributes no baseline vote rather than the old same-`x`, `0`-angle vote.

The new benchmark file `bench/deskew-angles.bench.ts` covers `calculateLineAngle`, `calculateBaselineAngles`, `calculateConsensusAngle`, and `calculateMinRectAngles`, recording runtime/spec metadata and using mitata controls (computed parameters, `do_not_optimize`, GC control) where useful.

The new test file `tests/deskew-angles.test.ts` pins the behavior of the three changed helpers, including the equal-width baseline heuristic and its single-bucket / two-bucket edge cases, and the consensus `totalWeight === 0` and median-fallback paths.

## Checklist

- [x] Tests pass locally (bun test)
- [x] Types are clean (bun run type-check)
- [x] Format is clean (bun run fmt)
- [x] Lint output reviewed (bun run lint)
- [x] Benchmark run if this touches a hot operation (bun task bench deskew-angles)
- [x] CHANGELOG updated under ## [Unreleased] (or bump version if cutting a release)
- [ ] README updated if the public API or setup changed
- [x] New tests added for bugs fixed or features added

## Compatibility

- [x] Node.js entry (ppu-ocv) — @napi-rs/canvas
- [ ] Web entry (ppu-ocv/web) — browser OpenCV.js + Canvas
- [ ] Canvas entry (ppu-ocv/canvas) — Node canvas, no OpenCV
- [ ] Canvas-web entry (ppu-ocv/canvas-web) — browser canvas, no OpenCV
- [ ] macOS
- [x] Linux
- [ ] Windows

## Related

N/A
