### PR TITLE
chore: release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [3.3.0] — 2026-06-22
 
 ### Added
 

--- a/index.html
+++ b/index.html
@@ -779,7 +779,7 @@
           <polyline points="22 8.5 12 15.5 2 8.5" />
         </svg>
         ppu-ocv
-        <span class="topbar-badge">v3.2.2</span>
+        <span class="topbar-badge">v3.3.0</span>
         <div class="topbar-links">
           <a
             href="https://github.com/PT-Perkasa-Pilar-Utama/ppu-ocv"
@@ -1107,7 +1107,7 @@
       } catch (e) {
         // Fallback to npm CDN if local build is missing or deployed to GH Pages
         console.log("Local build not found, falling back to CDN...");
-        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-ocv@3.2.2/index.web.js");
+        const cdn = await import("https://cdn.jsdelivr.net/npm/ppu-ocv@3.3.0/index.web.js");
         ImageProcessor = cdn.ImageProcessor;
         CanvasProcessor = cdn.CanvasProcessor;
         DeskewService = cdn.DeskewService;

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-ocv",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppu-ocv",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "A type-safe, modular, chainable image processing library built on top of OpenCV.js with a fluent API leveraging pipeline processing.",
   "keywords": [
     "open-cv",


### PR DESCRIPTION
## Release v3.3.0 — `ppu-ocv/canvas-mobile` (React Native / Skia)

Brings the mobile-canvas feature (originally PR #23, since rebased onto current
`main` with review blockers F1–F4/F6 resolved) and cuts the `3.3.0` release.

### Added
- **`ppu-ocv/canvas-mobile` entry point** — fourth public entry point backed by
  `@shopify/react-native-skia` (optional peer, ≥ 1.0.0). Same canvas-only
  surface as `ppu-ocv/canvas-web` (`CanvasProcessor`, `CanvasToolkitBase`,
  factory types) but registers the Skia-backed mobile platform. OpenCV is never
  imported — WASM-free on iOS/Android.
- **`prepareCanvas` / `bufferToCanvas` accept a URI string** — now
  `ArrayBuffer | string | CanvasLike`, routing strings through
  `platform.loadImage` for URI-based loading (`file://…`, `https://…`).
- Interactive Expo demo under `examples/expo-demo`.

### Verification (run on this branch)
- `bun test` — **149 pass / 0 fail**, 570 assertions across 17 files
- `bun run type-check` (tsgo) — clean
- `bun run lint` (oxlint) — 0 warnings / 0 errors
- `bun run fmt` (oxfmt) — clean
- `bun run build` — emits `lib/index.canvas-mobile.{js,d.ts}` + `lib/platform/mobile.js`
- Prepared publish manifest exposes the `./canvas-mobile` export, keeps the
  optional Skia peer dep, and strips the Skia devDependency from runtime deps

### Known limitation
The real Skia-backed adapter cannot run in Node/Bun, so the test suite exercises
it through a duck-typed mock — it validates entry-point shape, pixel layout, and
CanvasProcessor integration, **not** on-device rendering. Per the original PR,
Android was validated on a device; iOS is untested (no device available).

### Packaging
- `package.json`: `./canvas-mobile` export, optional `peerDependencies` +
  `peerDependenciesMeta`, `trustedDependencies`
- `jsr.json`: `./canvas-mobile` export
- Version bumped to `3.3.0` in `package.json`, `jsr.json`, demo `index.html`

Closes #2.
