### PR TITLE
chore: sync jsr.json to 4.0.0 and guard version mismatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ name: Publish
 on:
   release:
     types: [published]
+  # Manual trigger for re-publishing (e.g. jsr fell behind npm). Runs against
+  # the selected ref; the npm step below skips versions already published.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -66,7 +69,13 @@ jobs:
       # --provenance generates a signed SLSA attestation linking the tarball to
       # this commit + workflow run; requires the id-token: write permission above.
       - name: Publish to npm
-        run: npm publish ./lib --access=public --provenance
+        run: |
+          ver=$(node -p "require('./lib/package.json').version")
+          if npm view "ppu-ocv@$ver" version >/dev/null 2>&1; then
+            echo "ppu-ocv@$ver already published to npm, skipping."
+          else
+            npm publish ./lib --access=public --provenance
+          fi
 
       # Generate a CycloneDX SBOM and attach it to the GitHub release so
       # consumers can audit the dependency set of each version (QA-02.02).

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,3 +12,14 @@
 set -e
 
 bunx lint-staged
+
+# Keep package.json and jsr.json versions in lockstep — a mismatch means a
+# release bump touched one manifest but not the other (npm/jsr drift).
+ver() { sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -1; }
+pkg_ver=$(ver package.json)
+jsr_ver=$(ver jsr.json)
+if [ "$pkg_ver" != "$jsr_ver" ]; then
+  echo "Error: version mismatch — package.json=$pkg_ver jsr.json=$jsr_ver" >&2
+  echo "Bump both manifests to the same version before committing." >&2
+  exit 1
+fi

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowfluke/ppu-ocv",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",


### PR DESCRIPTION
Follow-up to the v4.0.0 release.

- Bumps `jsr.json` to 4.0.0 (it was missed in the release; npm and the
  GitHub release already shipped 4.0.0, jsr was still on 3.3.0).
- Adds a pre-commit guard that fails the commit when `package.json` and
  `jsr.json` versions diverge, so the two manifests can't drift again.