### PR TITLE
chore: guard release-only publish steps and clobber re-uploads

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,7 @@ jobs:
       # Generate a CycloneDX SBOM and attach it to the GitHub release so
       # consumers can audit the dependency set of each version (QA-02.02).
       - name: Generate and attach SBOM
+        if: github.event_name == 'release'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: cyclonedx-json
@@ -92,9 +93,11 @@ jobs:
       # assets for a signature/provenance file (npm provenance is not visible to
       # it), so we attach a cosign signature + Fulcio certificate per release.
       - name: Pack published tarball
+        if: github.event_name == 'release'
         run: npm pack ./lib --pack-destination "$RUNNER_TEMP"
 
       - name: Install cosign
+        if: github.event_name == 'release'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Keyless signing via OIDC (Sigstore/Fulcio) — no long-lived keys; uses the
@@ -102,6 +105,7 @@ jobs:
       # (.sigstore.json) holding the signature, Fulcio cert, and Rekor entry;
       # Scorecard's Signed-Releases check recognizes the .sigstore.json suffix.
       - name: Sign the tarball (keyless)
+        if: github.event_name == 'release'
         env:
           COSIGN_YES: "true"
         run: |
@@ -110,9 +114,10 @@ jobs:
           done
 
       - name: Attach signed artifacts to the GitHub release
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             "$RUNNER_TEMP"/*.tgz "$RUNNER_TEMP"/*.tgz.sigstore.json \
-            --repo "${{ github.repository }}"
+            --repo "${{ github.repository }}" --clobber


### PR DESCRIPTION
Follow-up to #38 (merged). Backports the same publish-workflow hardening
applied in ppu-paddle-ocr:

- **`if: github.event_name == 'release'`** on the SBOM/pack/cosign/sign/attach
  steps — a manual `workflow_dispatch` publishes jsr+npm and skips the
  release-asset machinery instead of erroring with no release context.
- **`--clobber`** on `gh release upload` — a release re-run no longer aborts
  when the signed asset already exists on the release.